### PR TITLE
adding support for mpq

### DIFF
--- a/lib/ctypes_zarith.c.ml
+++ b/lib/ctypes_zarith.c.ml
@@ -3,16 +3,17 @@ let%c () = header {|
 #include <zarith.h>
 |}
 
-let%c t = abstract "__mpz_struct"
+module MPZ = struct 
+  let%c t = abstract "__mpz_struct"
 
-external mpz_clear : t ptr -> void = "mpz_clear" [@@noalloc]
+  external mpz_clear : t ptr -> void = "mpz_clear" [@@noalloc]
 
-let make () =
-  (* allocate_n zero initializes the memory. It's safe to pass
-     such a struct to mpz_clear. *)
-  Ctypes.allocate_n ~finalise:mpz_clear t ~count:1
+  let make () =
+    (* allocate_n zero initializes the memory. It's safe to pass
+       such a struct to mpz_clear. *)
+    Ctypes.allocate_n ~finalise:mpz_clear t ~count:1
 
-external%c of_z : zt_:(Z.t[@ocaml_type]) -> tptr_:t ptr -> void = {|
+  external%c of_z : zt_:(Z.t[@ocaml_type]) -> tptr_:t ptr -> void = {|
    value z = $zt_; /* not converted. The usual rules for stub code must be
                       obeyed (accessors, memory management (GC), etc.) */
    __mpz_struct * p = $tptr_; /* already converted to a native c type, will not
@@ -20,18 +21,68 @@ external%c of_z : zt_:(Z.t[@ocaml_type]) -> tptr_:t ptr -> void = {|
    ml_z_mpz_init_set_z(p, z);
 |}
 
-let of_z x =
-  let r = make () in
-  of_z x r;
-  r
+  let of_z x =
+    let r = make () in
+    of_z x r;
+    r
 
-external%c to_z : ptr_:t ptr -> (Z.t[@ocaml_type]) = {|
+  external%c to_z : ptr_:t ptr -> (Z.t[@ocaml_type]) = {|
   return (ml_z_from_mpz($ptr_));
 |}
 
-let mpz_ptr = Ctypes.ptr t
+  let t_ptr = Ctypes.ptr t
 
-let mpz_srcptr : Z.t Ctypes.typ =
-  Ctypes.view
-    ~format_typ:(fun k fmt -> Format.fprintf fmt "mpz_ptr%t" k)
-    ~read:to_z ~write:of_z mpz_ptr
+  let zarith : Z.t Ctypes.typ =
+    Ctypes.view
+      ~format_typ:(fun k fmt -> Format.fprintf fmt "mpz_ptr%t" k)
+      ~read:to_z ~write:of_z t_ptr
+
+end
+
+module MPQ = struct 
+  let%c t = abstract "__mpq_struct"
+
+  external mpq_clear : t ptr -> void = "mpq_clear" [@@noalloc]
+
+  let make () =
+    (* allocate_n zero initializes the memory. It's safe to pass
+       such a struct to mpz_clear. *)
+    Ctypes.allocate_n ~finalise:mpq_clear t ~count:1
+
+  external%c of_zz : num_:(Z.t[@ocaml_type]) -> den_:(Z.t[@ocaml_type]) -> tptr_:t ptr -> void
+    = {|
+   value num = $num_; /* not converted. The usual rules for stub code must be
+                      obeyed (accessors, memory management (GC), etc.) */
+   value den = $den_; /* not converted. The usual rules for stub code must be
+                      obeyed (accessors, memory management (GC), etc.) */
+   __mpq_struct * p = $tptr_; /* already converted to a native c type, will not
+                                 be garbage collected during the stub code */
+   ml_z_mpz_init_set_z(&p->_mp_num, num);
+   ml_z_mpz_init_set_z(&p->_mp_den, den);
+|}
+
+  let of_q x =
+    let r = make () in
+    of_zz (Q.num x) (Q.den x) r;
+    r
+
+  external%c num : ptr_:t ptr -> (Z.t[@ocaml_type]) = {|
+  __mpq_struct * p = $ptr_;
+  return (ml_z_from_mpz(&p->_mp_num));
+|}
+
+  external%c den : ptr_:t ptr -> (Z.t[@ocaml_type]) = {|
+  __mpq_struct * p = $ptr_;
+  return (ml_z_from_mpz(&p->_mp_den));
+|}
+
+  let to_q x = Q.make (num x) (den x)
+
+  let t_ptr = Ctypes.ptr t
+
+  let zarith : Q.t Ctypes.typ =
+    Ctypes.view
+      ~format_typ:(fun k fmt -> Format.fprintf fmt "mpq_ptr%t" k)
+      ~read:to_q ~write:of_q t_ptr
+
+end

--- a/lib/ctypes_zarith.mli
+++ b/lib/ctypes_zarith.mli
@@ -1,12 +1,33 @@
-type t
+module MPZ : sig
 
-val make : unit -> t Ctypes.abstract Ctypes.ptr
-(** like {!Ctypes.make}, but with finalise and type already specified *)
+  type t
 
-val of_z : Z.t -> t Ctypes.abstract Ctypes.ptr
+  val make : unit -> t Ctypes.abstract Ctypes.ptr
+  (** like {!Ctypes.make}, but with finalise and type already specified *)
 
-val to_z : t Ctypes.abstract Ctypes.ptr -> Z.t
+  val of_z : Z.t -> t Ctypes.abstract Ctypes.ptr
 
-val mpz_srcptr : Z.t Ctypes.typ
+  val to_z : t Ctypes.abstract Ctypes.ptr -> Z.t
 
-val mpz_ptr : t Ctypes.abstract Ctypes.ptr Ctypes.typ
+  val zarith : Z.t Ctypes.typ
+
+  val t_ptr : t Ctypes.abstract Ctypes.ptr Ctypes.typ
+
+end
+
+module MPQ : sig
+
+  type t
+
+  val make : unit -> t Ctypes.abstract Ctypes.ptr
+  (** like {!Ctypes.make}, but with finalise and type already specified *)
+
+  val of_q : Q.t -> t Ctypes.abstract Ctypes.ptr
+
+  val to_q : t Ctypes.abstract Ctypes.ptr -> Q.t
+
+  val zarith : Q.t Ctypes.typ
+
+  val t_ptr : t Ctypes.abstract Ctypes.ptr Ctypes.typ
+
+end

--- a/test/run_tests.ml
+++ b/test/run_tests.ml
@@ -2,31 +2,56 @@ open Ctypes
 open Ctypes_zarith
 
 module Add = struct
-  let add =
+  let z_add =
     Foreign.foreign "__gmpz_add"
-      (mpz_ptr @-> mpz_srcptr @-> mpz_srcptr @-> returning void)
+      (MPZ.t_ptr @-> MPZ.zarith @-> MPZ.zarith @-> returning void)
 
-  let add a b =
-    let r = make () in
-    add r a b;
-    to_z r
+  let z_add a b =
+    let r = MPZ.make () in
+    z_add r a b;
+    MPZ.to_z r
+
+  let q_add =
+    Foreign.foreign "__gmpq_add"
+      (MPQ.t_ptr @-> MPQ.zarith @-> MPQ.zarith @-> returning void)
+
+  let q_add a b =
+    let r = MPQ.make () in
+    q_add r a b;
+    MPQ.to_q r
 
   let check x = Alcotest.(check bool) "" true x
 
   let test_add () =
-    check (Z.of_int 3 = add (Z.of_int 1) (Z.of_int 2));
-    let f n =
+    let one = Z.of_int 1 in
+    let two = Z.of_int 2 in
+    let three = Z.of_int 3 in
+    let six = Z.of_int 6 in
+    let (/) n d = Q.make n d in
+    check (three = z_add one two);
+    check (one / two = q_add (one / three) (one / six));
+    let fz n =
       let r = Z.(n + n) in
-      check (r = add n n)
+      check (r = z_add n n)
     in
     let n = Z.of_int max_int in
-    f n;
+    fz n;
     let n = Z.(n + n) in
-    f n;
+    fz n;
     let n = Z.(n * n) in
-    f n;
+    fz n;
     let n = Z.pow n 256 in
-    f n;
+    fz n;
+    let fq n =
+      let r = Q.(n + n) in
+      check (r = q_add n n)
+    in
+    let n = six / (Z.of_int max_int) in
+    fq n;
+    let n = Q.(n + n) in
+    fq n;
+    let n = Q.(n * n) in
+    fq n;
     ()
 end
 


### PR DESCRIPTION
I had tested your code and it worked beautifully; I just needed to handle mpq as well as mpz.
I tried to imitate what you did, and I added some tests. It seems to work.
I created two Ocaml modules MPZ and MPQ and mildly changed some value names, but I'm happy if you want different naming conventions.
Side-question: what do we do with this code? Shall we leave it as stand-alone, adding a licence, and make it available through opam?