### PR TITLE
Made visible 3 lower-level functions for each of MPZ and MPQ

### DIFF
--- a/lib/ctypes_zarith.c.ml
+++ b/lib/ctypes_zarith.c.ml
@@ -62,8 +62,10 @@ module MPQ = struct
                       obeyed (accessors, memory management (GC), etc.) */
    __mpq_struct * p = $tptr_; /* already converted to a native c type, will not
                                  be garbage collected during the stub code */
-   ml_z_mpz_init_set_z(&p->_mp_num, num);
-   ml_z_mpz_init_set_z(&p->_mp_den, den);
+   mpq_init(p);
+   ml_z_mpz_set_z(&p->_mp_num, num);
+   ml_z_mpz_set_z(&p->_mp_den, den);
+   mpq_canonicalize(p);
 |}]
 
   let init_set x r = init_set_zz (Q.num x) (Q.den x) r

--- a/lib/ctypes_zarith.mli
+++ b/lib/ctypes_zarith.mli
@@ -2,22 +2,27 @@ module MPZ : sig
 
   type t
 
+  type ptr = t Ctypes.abstract Ctypes.ptr
+
   val t : t Ctypes.abstract Ctypes.typ
 
-  val clear : t Ctypes.abstract Ctypes.ptr -> unit
+  val clear : ptr -> unit
 
-  val init_set : Z.t -> t Ctypes.abstract Ctypes.ptr -> unit
+  val init : ptr -> unit
 
-  val make : unit -> t Ctypes.abstract Ctypes.ptr
-  (** like {!Ctypes.make}, but with finalise and type already specified *)
+  val set : Z.t -> ptr -> unit
 
-  val of_z : Z.t -> t Ctypes.abstract Ctypes.ptr
+  val make : unit -> ptr
+  (** like {!Ctypes.make}, but with finalise and type already specified.
+  mpz is initialized. *)
 
-  val to_z : t Ctypes.abstract Ctypes.ptr -> Z.t
+  val of_z : Z.t -> ptr
+
+  val to_z : ptr -> Z.t
 
   val zarith : Z.t Ctypes.typ
 
-  val t_ptr : t Ctypes.abstract Ctypes.ptr Ctypes.typ
+  val t_ptr : ptr Ctypes.typ
 
 end
 
@@ -25,21 +30,26 @@ module MPQ : sig
 
   type t
 
+  type ptr = t Ctypes.abstract Ctypes.ptr
+
   val t : t Ctypes.abstract Ctypes.typ
 
-  val clear : t Ctypes.abstract Ctypes.ptr -> unit
+  val clear : ptr -> unit
 
-  val init_set : Q.t -> t Ctypes.abstract Ctypes.ptr -> unit
+  val init : ptr -> unit
 
-  val make : unit -> t Ctypes.abstract Ctypes.ptr
-  (** like {!Ctypes.make}, but with finalise and type already specified *)
+  val set  : Q.t -> ptr -> unit
 
-  val of_q : Q.t -> t Ctypes.abstract Ctypes.ptr
+  val make : unit -> ptr
+  (** like {!Ctypes.make}, but with finalise and type already specified.
+      mpq is initialized. *)
 
-  val to_q : t Ctypes.abstract Ctypes.ptr -> Q.t
+  val of_q : Q.t -> ptr
+
+  val to_q : ptr -> Q.t
 
   val zarith : Q.t Ctypes.typ
 
-  val t_ptr : t Ctypes.abstract Ctypes.ptr Ctypes.typ
+  val t_ptr : ptr Ctypes.typ
 
 end

--- a/lib/ctypes_zarith.mli
+++ b/lib/ctypes_zarith.mli
@@ -2,6 +2,12 @@ module MPZ : sig
 
   type t
 
+  val t : t Ctypes.abstract Ctypes.typ
+
+  val clear : t Ctypes.abstract Ctypes.ptr -> unit
+
+  val init_set : Z.t -> t Ctypes.abstract Ctypes.ptr -> unit
+
   val make : unit -> t Ctypes.abstract Ctypes.ptr
   (** like {!Ctypes.make}, but with finalise and type already specified *)
 
@@ -18,6 +24,12 @@ end
 module MPQ : sig
 
   type t
+
+  val t : t Ctypes.abstract Ctypes.typ
+
+  val clear : t Ctypes.abstract Ctypes.ptr -> unit
+
+  val init_set : Q.t -> t Ctypes.abstract Ctypes.ptr -> unit
 
   val make : unit -> t Ctypes.abstract Ctypes.ptr
   (** like {!Ctypes.make}, but with finalise and type already specified *)


### PR DESCRIPTION
By experimenting with the bindings I realised I need the 3 lower-level functions (clear, init_set, and the handler).
That's because in C functions manipulating GMP integers, you can find arrays of mpz integers, and these are not arrays of pointers but 2-dimensional arrays (because mpz_t is not a pointer but a 1-cell array). Hence, in order to feed the following C function (from my use case)
```
yices_poly_mpz(uint32_t n, const mpz_t z[], const term_t t[])
```
the current interface of ctypes-zarith was not sufficient: we need to allocate a contiguous array of mpz (and calling `MPZ.make()` one integer at a time doesn't make them contiguous). Hence the use to access the handler for `MPZ.t abstract`, `clear`, and `init_set` for doing an n-ary allocation and filling the cells.